### PR TITLE
Switched to platform.architecture() to determine bitness

### DIFF
--- a/rticonnextdds_connector.py
+++ b/rticonnextdds_connector.py
@@ -18,7 +18,7 @@ import weakref
 import platform
 import json 
 
-bits   = platform.machine();
+(bits, linkage)  = platform.architecture();
 osname = platform.system();
 
 if "64" in bits:


### PR DESCRIPTION
In order to determine which library to load, look into the executable "bitness" using platform.architecture instead of using platform.machine.

The current implementation failed to load the connector library if the python interpreter is a 32 bit executable in a 64 system.