### PR TITLE
Add python package support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .rticonnextdds_connector import *

--- a/rticonnextdds_connector/__init__.py
+++ b/rticonnextdds_connector/__init__.py
@@ -1,0 +1,1 @@
+from .rticonnextdds_connector import *

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -77,7 +77,7 @@ else:
 		print("platfrom not yet supported")
 
 path = os.path.dirname(os.path.realpath(__file__))
-path = path + os.sep + "lib" + os.sep + arch + os.sep;
+path = os.path.join(path, "..", "lib", arch);
 libname = libname + "." + post
 rti = ctypes.CDLL(os.path.join(path, libname), ctypes.RTLD_GLOBAL)
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,113 @@
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path, walk
+from shutil import copytree
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+# get list of dds lib binaries to include
+lib_files = []
+for root, dirs, files in walk('lib'):
+    for file in files:
+        lib_files.append(path.abspath(path.join(root, file)))
+
+module_dir = 'rticonnextdds_connector'
+
+setup(
+    name=module_dir,
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='5.2.0',
+
+    description='RTI Connector for Connext DDS',
+    long_description=long_description,
+
+    # The project's main homepage.
+    url='https://github.com/rticommunity/rticonnextdds-connector',
+
+    # Author details
+    author='Gianpiero Napoli',
+    author_email='gianpiero@rti.com',
+
+    # Choose your license
+    license='RTI',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 3 - Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: RTI License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+    ],
+
+    # What does your project relate to?
+    keywords='rti dds connext connector pub sub pub-sub',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages= [module_dir],
+
+    # Alternatively, if you want to distribute just a my_module.py, uncomment
+    # this:ex
+    #py_modules=["rticonnextdds_connector"],
+
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=[''],
+
+    # List additional groups of dependencies here (e.g. development
+    # dependencies). You can install these using the following syntax,
+    # for example:
+    # $ pip install -e .[dev,test]
+    extras_require={},
+
+    # If there are data files included in your packages that need to be
+    # installed, specify them here.  If using Python 2.6 or less, then these
+    # have to be included in MANIFEST.in as well.
+    package_data={
+        module_dir: lib_files
+    },
+
+    # Although 'package_data' is the preferred approach, in some case you may
+    # need to place data files outside of your packages. See:
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
+    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+    data_files=[],
+
+    # To provide executable scripts, use entry points in preference to the
+    # "scripts" keyword. Entry points provide cross-platform support and allow
+    # pip to create the appropriate form of executable for the target platform.
+    entry_points={},
+)


### PR DESCRIPTION
I want to resolve #28. I've added a simple `setup.py` and moved `rticonnextdds_connector.py` to its own module directory. 

I can install the package via `pip install .` (assuming `pwd` is the root dir) or by adding 

```
git+git://github.com/rticommunity/rticonnextdds-connector.git
```

to `requirements.txt`