### PR TITLE
COMMUNITY-68: update python script to download the rest of libraries instead of finishing when something fails

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0
 requests==2.30.0
 urllib3==2.0.2
+boto3==1.33.13


### PR DESCRIPTION
I updated the Python Script used to download libraries to continue even when a library download fails. It will fail at the end after everything is downloaded.

I also took advantage of this situation to use boto3 to download libraries of a specific version using the credentials.