### PR TITLE
COMMUNITY-70: fix python dependencies to be able to install them in the node 17 container

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0
 requests==2.30.0
-urllib3==2.0.2
+urllib3==1.26
 boto3==1.33.13


### PR DESCRIPTION
This downgrade is required because the Node 17 container uses an older python version and there are some incompatibilities:
```
The conflict is caused by:
    The user requested urllib3==2.0.2
    requests 2.30.0 depends on urllib3<3 and >=1.21.1
    botocore 1.33.13 depends on urllib3<1.27 and >=1.25.4; python_version < "3.10"


To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```