### PR TITLE
REL-2231 -- update dependent arch libs to 7.3.0.2 ...

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-version: 7.3.0
+version: 7.3.0.2
 
 architectures:
   linux-arm:


### PR DESCRIPTION
Required confg.yaml change to use the libs from the 7.3.0.2 build.