### PR TITLE
[7.3.0.2] Merge connector release to support/connector/1.3.0 (REL-2391)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-version: 7.3.0
+version: 7.3.0.2
 
 architectures:
   linux-arm:


### PR DESCRIPTION
### Merge release/connector/1.3.1 to support/connector/1.3.0.
This is part of three merge requests that will sync master, develop and **support**.
Following these three merges will be similar merges in repository rticonnextdds-connector-js. But we need this commit hashes first.